### PR TITLE
Refactoring train/test scripts.

### DIFF
--- a/test.py
+++ b/test.py
@@ -103,7 +103,7 @@ with torch.no_grad():
                 labels = labels.to(device)
                 outputs = model(images)
 
-            elif not(mlp is None) and not(cnn is None):
+            else: # elif not(mlp is None) and not(cnn is None):
                 # When MLP+CNN
                 inputs_values_normed = inputs_values_normed.to(device)
                 images = images.to(device)

--- a/test_multi.py
+++ b/test_multi.py
@@ -99,7 +99,7 @@ with torch.no_grad():
                 labels_multi = { label_name: labels.to(device) for label_name, labels in labels_dict.items() }
                 outputs = model(images)
 
-            elif not(mlp is None) and not(cnn is None):
+            else: # elif not(mlp is None) and not(cnn is None):
                 # When MLP+CNN
                 inputs_values_normed = inputs_values_normed.to(device)
                 images = images.to(device)

--- a/train.py
+++ b/train.py
@@ -105,7 +105,7 @@ for epoch in range(num_epochs):
                     labels = labels.to(device)
                     outputs = model(images)
 
-                elif not(mlp is None) and not(cnn is None):
+                else: # elif not(mlp is None) and not(cnn is None):
                     # When MLP+CNN
                     inputs_values_normed = inputs_values_normed.to(device)
                     images = images.to(device)

--- a/train_multi.py
+++ b/train_multi.py
@@ -101,7 +101,7 @@ for epoch in range(num_epochs):
                     labels_multi = { label_name: labels.to(device) for label_name, labels in labels_dict.items() }
                     outputs = model(images)
 
-                elif not(mlp is None) and not(cnn is None):
+                else: # elif not(mlp is None) and not(cnn is None):
                     # When MLP+CNN
                     inputs_values_normed = inputs_values_normed.to(device)
                     images = images.to(device)

--- a/work_all.sh
+++ b/work_all.sh
@@ -20,10 +20,10 @@ yy_code="./evaluation/yy.py"
 gpu_ids="-1"
 
 # Delete previous logs.
-rm -f ${train_log}
-rm -f ${test_log}
-rm -f ${roc_log}
-rm -f ${yy_log}
+rm -f "${train_log}"
+rm -f "${test_log}"
+rm -f "${roc_log}"
+rm -f "${yy_log}"
 
 #1 task,
 #2 csv_name,
@@ -37,7 +37,7 @@ rm -f ${yy_log}
 
 total=$(tail -n +2 "${hyperparameter_csv}" | wc -l)
 i=1
-for row in `tail -n +2 ${hyperparameter_csv}`; do
+for row in $(tail -n +2 "${hyperparameter_csv}"); do
   task=$(echo "${row}" | cut -d "," -f1)
   csv_name=$(echo "${row}" | cut -d "," -f2)
   image_dir=$(echo "${row}" | cut -d "," -f3)
@@ -55,14 +55,14 @@ for row in `tail -n +2 ${hyperparameter_csv}`; do
 
   # Traning
   echo "${python} ${train_code} --task ${task} --csv_name ${csv_name} --image_dir ${image_dir} --model ${model} --criterion ${criterion} --optimizer ${optimizer} --epochs ${epochs} --batch_size ${batch_size} --sampler ${sampler} --gpu_ids ${gpu_ids}"
-  ${python} ${train_code} --task ${task} --csv_name ${csv_name} --image_dir ${image_dir} --model ${model} --criterion ${criterion} --optimizer ${optimizer} --epochs ${epochs} --batch_size ${batch_size} --sampler ${sampler} --gpu_ids ${gpu_ids} 2>&1 | tee -a ${train_log}
+  "${python}" "${train_code}" --task "${task}" --csv_name "${csv_name}" --image_dir "${image_dir}" --model "${model}" --criterion "${criterion}" --optimizer "${optimizer}" --epochs "${epochs}" --batch_size "${batch_size}" --sampler "${sampler}" --gpu_ids "${gpu_ids}" 2>&1 | tee -a "${train_log}"
 
   echo ""
 
   # Test
   echo "${i}/${total}: Test starts..."
   echo "${python} ${test_code}"
-  ${python} ${test_code} 2>&1 | tee -a ${test_log}
+  "${python}" "${test_code}" 2>&1 | tee -a "${test_log}"
 
   echo ""
 
@@ -70,7 +70,7 @@ for row in `tail -n +2 ${hyperparameter_csv}`; do
   # Plot ROC
   echo "${i}/${total}: Plot ROC..."
   echo "${python} ${roc_code}"
-  ${python} ${roc_code} 2>&1 | tee -a ${roc_log}
+  "${python}" "${roc_code}" 2>&1 | tee -a "${roc_log}"
 
 
   # Regression

--- a/work_all.sh
+++ b/work_all.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -eu
 
 hyperparameter_csv="./hyperparameters/hyperparameter.csv"
 


### PR DESCRIPTION
# リファクタリング項目
## シェルスクリプト
- コマンド実行結果をとるときは、バッククオートを使わず `$(〜)` を使う。
  - `$()` のほうがネスト・クオートを使うときに読みやすい等のメリットがあるため。
- bashで変数参照するときは、安全のため原則的に "$aaa" のようにダブルクオートで囲む。
  - 理由は、以下のように、記号やスペースなどが変数に含まれるときに意図しない挙動になるためです。
    - 参考: https://tldp.org/LDP/abs/html/quotingvar.html
```bash
# 意図しない挙動になる例
aaa="My Documents"

# 誤った参照: My Documents というフォルダでなく、My、Documents という２つのフォルダが作成されてしまう。
# (mkdir ${aaa} でも同じ)
mkdir $aaa

# 正しい参照: My Documents というフォルダを作る
# (mkdir "${aaa}" でも同じ)
mkdir "$aaa"

# --------
# 悪意のある変数の例
bbb='a; rm -rf /'

# 誤った参照
# $bbb が展開されて、ls a コマンドの後、 rm -rf / コマンドが動いてしまう。
ls $bbb

# 正しい参照
# "a; rm -rf /" というファイル名を探す (rm -rf は実行されない)
ls "$bbb"

```
- "${aaa}"のような "${〜}" で変数参照する方式は、"${aaa}bbb" のように変数参照の直後に文字列が続く場合は有効ですが、単体での参照の場合はちょっと冗長なので "$aaa" のようにカッコなしの参照のほうが個人的には好きです。
- シェルスクリプトの冒頭で、 `set -eu` しておくとミスや意図しない挙動が減るので便利です。
    - `set -e` はエラー時に中断、`set -u` は存在しない変数参照の抑制です。
    - 参考: https://qiita.com/youcune/items/fcfb4ad3d7c1edf9dc96

## Python
- エラー処理について、クラスや関数でのエラー発生時は基本的に exit ではなく例外(raise XxxError とか)を使う。

# その他雑感
## 全体的なこと
- コードをきれいに保つためには、コーディング規約を定めると一貫性が出てメンテナンスしやすいです。
  - 複数人開発する時や、長期間メンテナンスするコードでは決めておくことが多いです。
  - Python は PEP8が主流っぽい。
      - https://qiita.com/simonritchie/items/bb06a7521ae6560738a7
