### PR TITLE
Fixed bugs of deepsurv.

### DIFF
--- a/config/criterion.py
+++ b/config/criterion.py
@@ -40,7 +40,7 @@ class Regularization(object):
 class NegativeLogLikelihood(nn.Module):
     def __init__(self, device):
         super(NegativeLogLikelihood, self).__init__()
-        self.L2_reg = 0.08
+        self.L2_reg = 0.05
         self.reg = Regularization(order=2, weight_decay=self.L2_reg)
         self.device = device
 
@@ -48,14 +48,14 @@ class NegativeLogLikelihood(nn.Module):
         mask = torch.ones(y.shape[0], y.shape[0]).to(self.device)
         mask[(y.T - y) > 0] = 0
         loss_1 = torch.exp(risk_pred) * mask
-        loss_2 = torch.sum(loss_1, dim=0) / torch.sum(mask, dim=0)
-        loss_3 = torch.log(loss_2).reshape(-1, 1)
+        loss_1 = torch.sum(loss_1, dim=0) / torch.sum(mask, dim=0)
+        loss_1 = torch.log(loss_1).reshape(-1, 1)
         num_occurs = torch.sum(e)
         if num_occurs.item() == 0.0:
             # To avoid dividing with zero, set small value as loss
             loss = torch.tensor([1e-7], requires_grad=True)
         else:
-            neg_log_loss = -torch.sum((risk_pred-loss_3) * e) / num_occurs
+            neg_log_loss = -torch.sum((risk_pred-loss_1) * e) / num_occurs
             l2_loss = self.reg(model)
             loss = neg_log_loss + l2_loss
         return loss

--- a/config/model.py
+++ b/config/model.py
@@ -289,9 +289,14 @@ class MLPCNN_Net(nn.Module):
 
     # Normalize tensor to [0, 1]
     def normalize_cnn_output(self, outputs_cnn):
+        # Note:
+        # Can not use sklearn.preprocessing.MinMaxScaler() because sklearn does not support GPU.
         max = outputs_cnn.max()
         min = outputs_cnn.min()
-        outputs_cnn_normed = (outputs_cnn - min) / (max - min)
+        if min == max:
+            outputs_cnn_normed = outputs_cnn - min   # ie. 0
+        else:
+            outputs_cnn_normed = (outputs_cnn - min) / (max - min)
         return outputs_cnn_normed
 
 


### PR DESCRIPTION
[Issue] loss becomes nan.

To be precise, the issue occurs when CNN always outputs the same values.

model.py: 
In def normalize_cnn_output(self, outputs_cnn), how to normalize of outputs of CNN was modified to avoid zero division.

criterion.py:
In class NegativeLogLikelihood(nn.Module), self.L2_reg = 0.05 was defined initially so that best_val_loss could be got with less epochs. It is need to adjust self.L2_reg depending on dataset. Note that originally, self.L2_reg = 0.08.
