### PR TITLE
Fixed debug of dataloader with respect to sampler.

### DIFF
--- a/dataloader/dataloader.py
+++ b/dataloader/dataloader.py
@@ -117,10 +117,10 @@ class LoadDataSet_MLP_CNN(Dataset):
         return id, raw_output, label, inputs_value_normed, image, split
 
 
-def dalaloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
+def dataloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
     assert (split_list is not None), 'Specify split to make dataloader.'
     if (args['task'] == 'regression'):
-        assert (args['sampler'] == 'no'), 'samper should be no when multi-ouputs regression, but yes was specified.'
+        assert (sampler == 'no'), 'samper should be no when regression, but yes was specified.'
 
     split_data = LoadDataSet_MLP_CNN(args, csv_dict, images_dir, split_list)
 

--- a/dataloader/dataloader_deepsurv.py
+++ b/dataloader/dataloader_deepsurv.py
@@ -128,13 +128,13 @@ class LoadDataSet_DeepSurv(Dataset):
 
 
 
-def dalaloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
+def dataloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
     assert (split_list is not None), 'Specify split to make dataloader.'
 
     split_data = LoadDataSet_DeepSurv(args, csv_dict, images_dir, split_list)
 
     # Make sampler
-    if args['sampler'] == 'yes':
+    if sampler == 'yes':
         target = []
         for _, (_, _, label, _, _, _, _) in enumerate(split_data):
             target.append(label)

--- a/dataloader/dataloader_multi.py
+++ b/dataloader/dataloader_multi.py
@@ -126,7 +126,7 @@ class LoadDataSet_MLP_CNN(Dataset):
 
 def dataloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
     assert (split_list is not None), 'Specify split to make dataloader.'
-    assert (sampler == 'no'), 'samper should be no when multi-ouputs classification, but yes was specified.'
+    assert (sampler == 'no'), 'samper should be no when multi-ouputs classification or multi-outputs regresson, but yes was specified.'
 
     split_data = LoadDataSet_MLP_CNN(args, csv_dict, images_dir, split_list)
     split_loader = DataLoader(

--- a/dataloader/dataloader_multi.py
+++ b/dataloader/dataloader_multi.py
@@ -124,9 +124,9 @@ class LoadDataSet_MLP_CNN(Dataset):
         return id, raw_output_dict, label_dict, inputs_value_normed, image, split
 
 
-def dalaloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
+def dataloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
     assert (split_list is not None), 'Specify split to make dataloader.'
-    assert (args['sampler'] == 'no'), 'samper should be no when multi-ouputs classification, but yes was specified.'
+    assert (sampler == 'no'), 'samper should be no when multi-ouputs classification, but yes was specified.'
 
     split_data = LoadDataSet_MLP_CNN(args, csv_dict, images_dir, split_list)
     split_loader = DataLoader(

--- a/test.py
+++ b/test.py
@@ -52,8 +52,8 @@ else:
         from dataloader.dataloader_multi import *
     else:
         from dataloader.dataloader import *
-val_loader = dalaloader_mlp_cnn(train_hyperparameters, csv_dict, image_dir, split_list=['val'], batch_size=test_batch_size, sampler='no')
-test_loader = dalaloader_mlp_cnn(train_hyperparameters, csv_dict, image_dir, split_list=['test'], batch_size=test_batch_size, sampler='no')
+val_loader = dataloader_mlp_cnn(train_hyperparameters, csv_dict, image_dir, split_list=['val'], batch_size=test_batch_size, sampler='no')
+test_loader = dataloader_mlp_cnn(train_hyperparameters, csv_dict, image_dir, split_list=['test'], batch_size=test_batch_size, sampler='no')
 
 # Configure of model
 model = create_mlp_cnn(mlp, cnn, num_inputs, label_num_classes, gpu_ids=gpu_ids)

--- a/train.py
+++ b/train.py
@@ -50,8 +50,8 @@ else:
         from dataloader.dataloader_multi import *
     else:
         from dataloader.dataloader import *
-train_loader = dalaloader_mlp_cnn(args, csv_dict, image_dir, split_list=['train'], batch_size=batch_size, sampler=sampler)
-val_loader = dalaloader_mlp_cnn(args, csv_dict, image_dir, split_list=['val'], batch_size=batch_size, sampler=sampler)
+train_loader = dataloader_mlp_cnn(args, csv_dict, image_dir, split_list=['train'], batch_size=batch_size, sampler=sampler)
+val_loader = dataloader_mlp_cnn(args, csv_dict, image_dir, split_list=['val'], batch_size=batch_size, sampler=sampler)
 
 # Configure of training
 model = create_mlp_cnn(mlp, cnn, num_inputs, label_num_classes, gpu_ids=gpu_ids)


### PR DESCRIPTION
Issue:
when `sampler = 'yes'` in training, sampler works unexpectedly even if `dataloader_mlp_cnn( ... , sampler='no')` in test.

Fixed:
Deleted reference of `args['sampler']` in `dataloader/dataloader.py`, `dataloader/dataloader_deepsurv.py`, and `dataloader/dataloader_multi.py`.

modified:   dataloader/dataloader.py
modified:   dataloader/dataloader_deepsurv.py
modified:   dataloader/dataloader_multi.py
modified:   test.py
modified:   train.py