### PR TITLE
Refactor: make def parce_csv() class and rename output_ label_.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 # ----- Define variables -----
-# CSV_NAME = clean.csv
+# CSV_NAME = trials.csv
 # IMAGE_DIR = 128 | covid | png256
 # TASK = classification | regression | deepsurv
 # MODEL = MLP | ResNet18 | MLP+ResNet18
 # CRITERION = CEL | MSE | NLL
 # SAMPLER = yes | no    # should be no when regression or multi-label
-#GPU_IDS = -1 | 0,1,2
-CSV_NAME := clean.csv
+# GPU_IDS = -1 | 0,1,2
+CSV_NAME := trials.csv
 IMAGE_DIR := 128
-TASK := deepsurv
-MODEL := MLP
-CRITERION := NLL
+TASK := classification
+MODEL := MLP+ResNet18
+CRITERION := CEL
 OPTIMIZER := Adam
 EPOCHS := 3
 BATCH_SIZE := 64
@@ -37,7 +37,6 @@ TEST_CODE := test.py
 ROC_CODE := ./evaluation/roc.py
 YY_CODE := ./evaluation/yy.py
 C_INDEX_CODE := ./evaluation/c_index.py
-GRADCAM_CODE := visualize.py
 
 # Directory
 PARAMETER_DIR := ./parameters
@@ -80,6 +79,3 @@ yy:
 
 c_index:
 	$(PYTHON) $(C_INDEX_CODE)
-
-gradcam:
-	$(PYTHON) $(GRADCAM_CODE)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # TASK = classification | regression | deepsurv
 # MODEL = MLP | ResNet18 | MLP+ResNet18
 # CRITERION = CEL | MSE | NLL
-# SAMPLER = yes | no    # should be no when regression or multi-label
+# SAMPLER = yes | no   # should be no when regression or multi-label
 # GPU_IDS = -1 | 0,1,2
 CSV_NAME := trials.csv
 IMAGE_DIR := 128
@@ -15,6 +15,7 @@ OPTIMIZER := Adam
 EPOCHS := 3
 BATCH_SIZE := 64
 SAMPLER := no
+AUGMENTATION := yes
 GPU_IDS := -1
 
 TRAIN_OPT := \
@@ -27,7 +28,9 @@ TRAIN_OPT := \
 --epochs $(EPOCHS) \
 --batch_size $(BATCH_SIZE) \
 --sampler $(SAMPLER) \
+--augmentation $(AUGMENTATION) \
 --gpu_ids $(GPU_IDS)
+
 
 PYTHON := python -i
 #PYTHON := python

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Set directories as follows.
 
 - Brief modification for your task
   - parameters/parameters.csv  
-    CSV must contain columns named `id_XXX`, `filepath`, `output_XXX`, and `split`.  
+    CSV must contain columns named `id_XXX`, `filepath`, `label_XXX`, and `split`.  
     Detailed explanation is shown in below.
   - work_all.sh  
     Change `gpu_ids` depending on how many GPUs you can use. Default is "-1" which means to use CPU only.
@@ -35,10 +35,10 @@ https://colab.research.google.com/drive/1vpP-veRHPnTEwzDOzRZ0cXcHHY0u7-oJ
 # Detailed Preparation
 ## CSV
 This is the csv which we show as trials.csv in the brief usage section.  
-CSV must contain columns named `id_XXX`, `filepath`, `output_XXX`, and `split`.
+CSV must contain columns named `id_XXX`, `filepath`, `label_XXX`, and `split`.
 
 Examples:
-| id_uniq | filepath | output_cancer | split |
+| id_uniq | filepath | label_cancer | split |
 | -----| ----------- | --------- | ----- |
 | 0001 | png_128/AAA.png | malignant | train |
 | 0002 | png_128/BBB.png | benign | val |
@@ -53,7 +53,7 @@ Examples:
 
 Note `id_XXX` must be unique.
 `filepath` should have a path to images for the model.
-`output_XXX` should have a classification target. Any name is available. If you use more than two `output_XXX`, it will be automatically recognize multi-label classification and automatically prepare a proper number of classifiers (FCs). 
+`label_XXX` should have a classification target. Any name is available. If you use more than two `label_XXX`, it will be automatically recognize multi-label classification and automatically prepare a proper number of classifiers (FCs). 
 `split` should have `train`, `val`, and `test`.
 When you use inputs other than image, `input_XXX` is needed. 
 When you use deepsurv, `periords_XXX` is needed as well.

--- a/config/model.py
+++ b/config/model.py
@@ -250,22 +250,21 @@ class MLPCNN_Net(nn.Module):
         outputs = self.mlp(inputs_images)
         return outputs
 
-
-def create_mlp_cnn(mlp, cnn, num_inputs, label_num_classes, gpu_ids=[]):
+def create_mlp_cnn(mlp, cnn, num_inputs, num_classes_in_label, gpu_ids=[]):
     """
     num_input: number of inputs of MLP or MLP+CNN
     """
     if (mlp is not None) and (cnn is None):
         # When MLP only
-        model = mlp_net(num_inputs, label_num_classes)
+        model = mlp_net(num_inputs, num_classes_in_label)
     elif (mlp is None) and (cnn is not None):
         # When CNN only
-        model = conv_net(cnn, label_num_classes)
+        model = conv_net(cnn, num_classes_in_label)
     else:
         # When MLP+CNN
         # Set the number of outputs from CNN to MLP as 1, then
         # the shape of outputs from CNN is [batgch_size,1]
-        model = MLPCNN_Net(cnn, num_inputs, label_num_classes)
+        model = MLPCNN_Net(cnn, num_inputs, num_classes_in_label)
 
     #model = config_device(model, gpu_ids)
     device = set_device(gpu_ids)

--- a/dataloader/dataloader_multi.py
+++ b/dataloader/dataloader_multi.py
@@ -19,31 +19,30 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from lib.util import *
 
 
+
 class LoadDataSet_MLP_CNN(Dataset):
-    def __init__(self, args, csv_dict, image_dir, split_list):
+    def __init__(self, args, split_provider, image_dir, split_list):
         #super(LoadDataSet_MLP_CNN, self).__init__()
         super().__init__()
 
         self.args = args
-        self.csv_dict = csv_dict
+        self.split_provider = split_provider
         self.image_dir = image_dir
         self.split_list = split_list   # ['train'], ['val'], ['val', 'test'], ['train', 'val', 'test']        
 
-        self.df_source = self.csv_dict['source']
-        self.id_column = self.csv_dict['id_column']
-
-        self.output_list = self.csv_dict['output_list']
-        self.label_list = self.csv_dict['label_list']
-
-        self.input_list = self.csv_dict['input_list']
-        self.filepath_column = self.csv_dict['filepath_column']
-        self.split_column = self.csv_dict['split_column']
+        self.df_source = self.split_provider.df_source
+        self.id_column = self.split_provider.id_column
+        self.raw_label_list = self.split_provider.raw_label_list
+        self.internal_label_list =  self.split_provider.internal_label_list
+        self.input_list = self.split_provider.input_list
+        self.filepath_column = self.split_provider.filepath_column
+        self.split_column = self.split_provider.split_column
         self.df_split = get_column_value(self.df_source, self.split_column, self.split_list)
 
 
         # Nomalize input variables
         if not(self.args['mlp'] is None):
-            self.input_list_normed = [ 'normed_' + input for input in self.input_list ]
+            self.input_list_normed = ['normed_' + input for input in self.input_list]
             self.scaler = MinMaxScaler()
             self.df_train = get_column_value(self.df_source, self.split_column, ['train'])  # should be normalized with min and max of training data
             _ = self.scaler.fit(self.df_train[self.input_list])                             # fit only
@@ -100,8 +99,8 @@ class LoadDataSet_MLP_CNN(Dataset):
 
     def __getitem__(self, idx):
         id = self.df_split.iat[idx, self.index_dict[self.id_column]]
-        raw_output_dict = {output_name: self.df_split.iat[idx, self.index_dict[output_name]] for output_name in self.output_list}
-        label_dict = {label_name: self.df_split.iat[idx, self.index_dict[label_name]] for label_name in self.label_list}
+        raw_label_dict = {row_label_name: self.df_split.iat[idx, self.index_dict[row_label_name]] for row_label_name in self.raw_label_list}
+        internal_label_dict = {internal_label_name: self.df_split.iat[idx, self.index_dict[internal_label_name]] for internal_label_name in self.internal_label_list}
         split = self.df_split.iat[idx, self.index_dict[self.split_column]]
 
         # Convert normalized values to a single Tensor
@@ -125,15 +124,14 @@ class LoadDataSet_MLP_CNN(Dataset):
         else:
             image = ''
 
-        #return id, label, inputs_value_normed, image, split
-        return id, raw_output_dict, label_dict, inputs_value_normed, image, split
+        return id, raw_label_dict, internal_label_dict, inputs_value_normed, image, split
 
 
-def dataloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=None, sampler=None):
+def dataloader_mlp_cnn(args, split_provider, images_dir, split_list=None, batch_size=None, sampler=None):
     assert (split_list is not None), 'Specify split to make dataloader.'
     assert (sampler == 'no'), 'samper should be no when multi-ouputs classification or multi-outputs regresson, but yes was specified.'
 
-    split_data = LoadDataSet_MLP_CNN(args, csv_dict, images_dir, split_list)
+    split_data = LoadDataSet_MLP_CNN(args, split_provider, images_dir, split_list)
     split_loader = DataLoader(
                             dataset = split_data,
                             batch_size = batch_size,
@@ -141,6 +139,3 @@ def dataloader_mlp_cnn(args, csv_dict, images_dir, split_list=None, batch_size=N
                             num_workers = 0,
                             sampler = None)
     return split_loader
-
-
-# ----- EOF -----

--- a/evaluation/c_index.py
+++ b/evaluation/c_index.py
@@ -18,52 +18,52 @@ from lib.align_env import *
 from options.metrics_options import MetricsOptions
 
 
-args = MetricsOptions().parse()
 nervusenv = NervusEnv()
+args = MetricsOptions().parse()
 datetime_dir = get_target(nervusenv.sets_dir, args['likelihood_datetime'])   # args['likelihood_datetime'] if exists or the latest
 likelihood_path = os.path.join(datetime_dir, nervusenv.csv_likelihood)
 df_likelihood = pd.read_csv(likelihood_path)
-output_name = [column_name for column_name in df_likelihood.columns if column_name.startswith('output')][0]
-period_name = [column_name for column_name in df_likelihood.columns if column_name.startswith('periods')][0]
+
 
 @dataclasses.dataclass
 class LabelCIndex:
     val: float
     test: float
 
-def cal_c_index(df_likelihood, output_name, period_name):
-    pred_name = 'pred_' + output_name
-    label_name = 'label_' + output_name
+
+def cal_c_index(df_likelihood, label_name, period_name):
+    pred_name = 'pred_' + label_name
+    internal_label_name = 'internal_label' + label_name.replace('label', '')   #   label_XXX -> label_internal_XXX
     for split in ['val', 'test']:
         df_likelihood_split = get_column_value(df_likelihood, 'split', [split])
         periods_split = df_likelihood_split[period_name].values
         preds_split = df_likelihood_split[pred_name].values
-        #outputs_split = df_likelihood_split[output_name].values
-        labels_split = df_likelihood_split[label_name].values
-        c_index_split = concordance_index(periods_split, (-1)*preds_split, labels_split)
+        internal_labels_split = df_likelihood_split[internal_label_name].values
+        c_index_split = concordance_index(periods_split, (-1)*preds_split, internal_labels_split)
         if split == 'val':
             c_index_val = c_index_split
         else:
             c_index_test = c_index_split
-    output_c_index = LabelCIndex(val=c_index_val, test=c_index_test)
-    print(f"{output_name}, val: {output_c_index.val:.2f}, test: {output_c_index.test:.2f}")
-    return output_c_index
+    label_c_index = LabelCIndex(val=c_index_val, test=c_index_test)
+    print(f"{label_name}, val: {label_c_index.val:.2f}, test: {label_c_index.test:.2f}")
+    return label_c_index
 
-output_c_index = cal_c_index(df_likelihood, output_name, period_name)
+
+# Calculate c-index
+label_name = list(df_likelihood.columns[df_likelihood.columns.str.startswith('label')])[0]
+period_name = list(df_likelihood.columns[df_likelihood.columns.str.startswith('periods')])[0]
+label_c_index = cal_c_index(df_likelihood, label_name, period_name)
 
 
 # Save c-index in summary.csv
 datetime = os.path.basename(datetime_dir)
 summary_new = dict()
 summary_new['datetime'] = [datetime]
-summary_new[output_name+'_val_c_index'] = [f"{output_c_index.val:.2f}"]
-summary_new[output_name+'_test_c_index'] = [f"{output_c_index.test:.2f}"]
+summary_new[label_name + '_val_c_index'] = [f"{label_c_index.val:.2f}"]
+summary_new[label_name + '_test_c_index'] = [f"{label_c_index.test:.2f}"]
 df_summary_new = pd.DataFrame(summary_new)
 update_summary(nervusenv.summary_dir, nervusenv.csv_summary, df_summary_new)
-
 
 # Save c-index in c_index.csv
 c_index_path = os.path.join(datetime_dir, nervusenv.csv_c_index)
 df_summary_new.to_csv(c_index_path, index=False)
-
-# ----- EOF -----

--- a/evaluation/roc.py
+++ b/evaluation/roc.py
@@ -20,12 +20,12 @@ from lib.align_env import *
 from options.metrics_options import MetricsOptions
 
 
-args = MetricsOptions().parse()
 nervusenv = NervusEnv()
+args = MetricsOptions().parse()
 datetime_dir = get_target(nervusenv.sets_dir, args['likelihood_datetime'])   # args['likelihood_datetime'] if exists or the latest
 likelihood_path = os.path.join(datetime_dir, nervusenv.csv_likelihood)
 df_likelihood = pd.read_csv(likelihood_path)
-output_list = [column_name for column_name in df_likelihood.columns if column_name.startswith('output')]
+
 
 @dataclasses.dataclass
 class AverageType:
@@ -39,134 +39,136 @@ class ROC:
     auc: AverageType
 
 @dataclasses.dataclass
-class OutputROC:
+class LabelROC:
     val: ROC
     test: ROC
 
 
 # ROC for single-output-binary-class
-def cal_roc_binary_class(output_name, df_likelihood):
-    output_roc = OutputROC(val=None, test=None)
+def cal_roc_binary_class(label_name, df_likelihood):
+    label_roc = LabelROC(val=None, test=None)
     POSITIVE = 1
-    pred_name_list = [column_name for column_name in df_likelihood.columns if column_name.startswith('pred_'+output_name)]
+    pred_name_list = list(df_likelihood.columns[df_likelihood.columns.str.startswith('pred')])
     pred_positive_name = pred_name_list[POSITIVE]
-    class_list = [column_name.rsplit('_', 1)[1] for column_name in pred_name_list]   # [pred_output_discharge, pred_output_decease] -> ['discharge', 'decease']
+    class_list = [column_name.rsplit('_', 1)[1] for column_name in pred_name_list]   # [pred_label_discharge, pred_label_decease] -> ['discharge', 'decease']
     positive_class = class_list[POSITIVE]
-    #print(pred_positive_name)
     for split in ['val', 'test']:
         df_likelihood_split = df_likelihood[df_likelihood['split']==split]
-        y_true_split = df_likelihood_split[output_name]
+        y_true_split = df_likelihood_split[label_name]
         y_score_split = df_likelihood_split[pred_positive_name]
         fpr_split, tpr_split, thresholds_split = metrics.roc_curve(y_true_split.astype('str'), y_score_split, pos_label=positive_class)
         if split == 'val':
-            output_roc.val = ROC(fpr=AverageType(micro=fpr_split),
+            label_roc.val = ROC(fpr=AverageType(micro=fpr_split),
                                  tpr=AverageType(micro=tpr_split),
                                  auc=AverageType(micro=metrics.auc(fpr_split, tpr_split)))
         else:
-            output_roc.test = ROC(fpr=AverageType(micro=fpr_split),
+            label_roc.test = ROC(fpr=AverageType(micro=fpr_split),
                                   tpr=AverageType(micro=tpr_split),
                                   auc=AverageType(micro=metrics.auc(fpr_split, tpr_split)))
-    print(f"{output_name}, val: {output_roc.val.auc.micro:.2f}, test: {output_roc.test.auc.micro:.2f}")
-    return output_roc
+    print(f"{label_name}, val: {label_roc.val.auc.micro:.2f}, test: {label_roc.test.auc.micro:.2f}")
+    return label_roc
 
 
 # Macro-average ROC for single-output-multi-class
-def cal_roc_multi_class(output_name, df_likelihood):
-    pred_name_list = [column_name for column_name in df_likelihood if column_name.startswith('pred_'+output_name)]
-    class_list = [column_name.rsplit('_', 1)[1] for column_name in pred_name_list]   # ['pred_output_discharge', ...] -> ['discharge', ...]
+def cal_roc_multi_class(label_name, df_likelihood):
+    pred_name_list = list(df_likelihood.columns[df_likelihood.columns.str.startswith('pred')])
+    class_list = [column_name.rsplit('_', 1)[1] for column_name in pred_name_list]   # [pred_label_discharge, pred_label_decease] -> ['discharge', 'decease']
     num_classes = len(class_list)
 
     for split in ['val', 'test']:
         df_likelihood_split = df_likelihood[df_likelihood['split']==split]
+        y_true_split = df_likelihood_split[label_name]
         df_y_score_split = df_likelihood_split[pred_name_list]
         #auc_one_vs_rest = metrics.roc_auc_score(y_true_binarized, df_y_score_split, multi_class='ovr', average='macro')   # OneVsRest
         #auc_one_vs_one = metrics.roc_auc_score(y_true_binarized, df_y_score_split, multi_class='ovo', average='macro')    # OneVsOne
-        y_true_binarized = label_binarize(df_likelihood_split[output_name], classes=class_list)
+        y_true_binarized = label_binarize(y_true_split, classes=class_list)
 
-        output_fpr_split = {}
-        output_tpr_split = {}
-        #output_roc_auc = {}
+        label_fpr_split = {}
+        label_tpr_split = {}
+        #label_roc_auc = {}
         for i in range(num_classes):
             class_name = class_list[i]
-            pred_name = 'pred_' + output_name + '_' + class_name
-            output_fpr_split[class_name], output_tpr_split[class_name], _ = metrics.roc_curve(y_true_binarized[:, i], df_y_score_split[pred_name])
-            #output_roc_auc[class_name] = metrics.auc(output_fpr[class_name], output_tpr[class_name])  # AUC for class_name
+            pred_name = 'pred_' + label_name + '_' + class_name
+            label_fpr_split[class_name], label_tpr_split[class_name], _ = metrics.roc_curve(y_true_binarized[:, i], df_y_score_split[pred_name])
+            #label_roc_auc[class_name] = metrics.auc(label_fpr[class_name], label_tpr[class_name])  # AUC for class_name
 
         # Compute macro-average ROC
         # Aggregate all false positive rates
-        output_all_fpr_split = np.unique(np.concatenate([output_fpr_split[class_name] for class_name in class_list]))
+        label_all_fpr_split = np.unique(np.concatenate([label_fpr_split[class_name] for class_name in class_list]))
 
         # Interpolate all ROC curves at this points
-        output_mean_tpr_split = np.zeros_like(output_all_fpr_split)
+        label_mean_tpr_split = np.zeros_like(label_all_fpr_split)
         for class_name in class_list:
-            output_mean_tpr_split += np.interp(output_all_fpr_split, output_fpr_split[class_name], output_tpr_split[class_name])
+            label_mean_tpr_split += np.interp(label_all_fpr_split, label_fpr_split[class_name], label_tpr_split[class_name])
 
         # Average it and compute AUC
-        output_mean_tpr_split /= num_classes
+        label_mean_tpr_split /= num_classes
 
         if split == 'val':
-            output_roc_val = ROC(fpr=AverageType(macro=output_all_fpr_split),
-                                 tpr=AverageType(macro=output_mean_tpr_split),
-                                 auc=AverageType(macro=metrics.auc(output_all_fpr_split, output_mean_tpr_split)))
+            label_roc_val = ROC(fpr=AverageType(macro=label_all_fpr_split),
+                                 tpr=AverageType(macro=label_mean_tpr_split),
+                                 auc=AverageType(macro=metrics.auc(label_all_fpr_split, label_mean_tpr_split)))
         else:
-            output_roc_test = ROC(fpr=AverageType(macro=output_all_fpr_split),
-                                  tpr=AverageType(macro=output_mean_tpr_split),
-                                  auc=AverageType(macro=metrics.auc(output_all_fpr_split, output_mean_tpr_split)))
+            label_roc_test = ROC(fpr=AverageType(macro=label_all_fpr_split),
+                                  tpr=AverageType(macro=label_mean_tpr_split),
+                                  auc=AverageType(macro=metrics.auc(label_all_fpr_split, label_mean_tpr_split)))
 
-    output_roc = OutputROC(val=output_roc_val, test=output_roc_test)
-    print(f"{output_name}, val: {output_roc.val.auc.macro:.2f}, test: {output_roc.test.auc.macro:.2f}")
-    return output_roc
+    label_roc = LabelROC(val=label_roc_val, test=label_roc_test)
+    print(f"{label_name}, val: {label_roc.val.auc.macro:.2f}, test: {label_roc.test.auc.macro:.2f}")
+    return label_roc
 
+
+# Calculate ROC and AUC
+label_list = list(df_likelihood.columns[df_likelihood.columns.str.startswith('label')])
 metrics_roc = {}
-for output_name in output_list:
-    num_class_of_output = df_likelihood[output_name].nunique()
-    if num_class_of_output <= 2:
-        metrics_roc[output_name] = cal_roc_binary_class(output_name, df_likelihood)
+for label_name in label_list:
+    num_class_in_label = df_likelihood[label_name].nunique()
+    if num_class_in_label > 2:
+        metrics_roc[label_name] = cal_roc_multi_class(label_name, df_likelihood)
     else:
-        metrics_roc[output_name] = cal_roc_multi_class(output_name, df_likelihood)
+        metrics_roc[label_name] = cal_roc_binary_class(label_name, df_likelihood)
 
 
 # Plot ROC
 num_rows = 1
-num_cols = len(output_list)
+num_cols = len(label_list)
 base_size = 7
 height = num_rows * base_size
 width = num_cols * height 
 
 fig = plt.figure(figsize=(width, height))
-for i in range(len(output_list)):
+for i in range(len(label_list)):
     offset = i + 1
-    output_name = output_list[i]
-    output_roc = metrics_roc[output_name]
+    label_name = label_list[i]
+    label_roc = metrics_roc[label_name]
+    num_class_in_label = df_likelihood[label_name].nunique()
 
-    num_class_of_output = df_likelihood[output_name].nunique()
-
-    if num_class_of_output <= 2:
-        # Ordinary ROC for binaryclass
-        fpr_val = output_roc.val.fpr.micro
-        tpr_val = output_roc.val.tpr.micro
-        auc_val = output_roc.val.auc.micro
-        fpr_test = output_roc.test.fpr.micro
-        tpr_test = output_roc.test.tpr.micro
-        auc_test = output_roc.test.auc.micro
-    else:
+    if num_class_in_label > 2:
         # macro-average ROC for multiclass
-        fpr_val = output_roc.val.fpr.macro
-        tpr_val = output_roc.val.tpr.macro
-        auc_val = output_roc.val.auc.macro
-        fpr_test = output_roc.test.fpr.macro
-        tpr_test = output_roc.test.tpr.macro
-        auc_test = output_roc.test.auc.macro
+        fpr_val = label_roc.val.fpr.macro
+        tpr_val = label_roc.val.tpr.macro
+        auc_val = label_roc.val.auc.macro
+        fpr_test = label_roc.test.fpr.macro
+        tpr_test = label_roc.test.tpr.macro
+        auc_test = label_roc.test.auc.macro
+    else:
+        # Ordinary ROC for binaryclass
+        fpr_val = label_roc.val.fpr.micro
+        tpr_val = label_roc.val.tpr.micro
+        auc_val = label_roc.val.auc.micro
+        fpr_test = label_roc.test.fpr.micro
+        tpr_test = label_roc.test.tpr.micro
+        auc_test = label_roc.test.auc.micro
 
     ax_i = fig.add_subplot(num_rows,
                            num_cols,
                            offset,
-                           title=output_name,
+                           title=label_name,
                            xlabel='1 - Specificity',
                            ylabel='Sensitivity',
                            xmargin=0,
                            ymargin=0)
-    
+
     ax_i.plot(fpr_val, tpr_val, label=f"AUC_val = {auc_val:.2f}", marker='x')
     ax_i.plot(fpr_test, tpr_test, label=f"AUC_test = {auc_test:.2f}", marker='o')
     ax_i.grid()
@@ -183,13 +185,10 @@ plt.savefig(roc_path)
 datetime = os.path.basename(datetime_dir)
 summary_new = dict()
 summary_new['datetime'] = [datetime]
-for output_name, output_roc in metrics_roc.items():
-    auc_val = output_roc.val.auc.micro if (output_roc.val.auc.micro is not None) else output_roc.val.auc.macro
-    auc_test = output_roc.test.auc.micro if (output_roc.test.auc.micro is not None) else output_roc.test.auc.macro
-    summary_new[output_name+'_val_auc'] = [f"{auc_val:.2f}"]
-    summary_new[output_name+'_test_auc'] = [f"{auc_test:.2f}"]
+for label_name, label_roc in metrics_roc.items():
+    auc_val = label_roc.val.auc.micro if (label_roc.val.auc.micro is not None) else label_roc.val.auc.macro
+    auc_test = label_roc.test.auc.micro if (label_roc.test.auc.micro is not None) else label_roc.test.auc.macro
+    summary_new[label_name+'_val_auc'] = [f"{auc_val:.2f}"]
+    summary_new[label_name+'_test_auc'] = [f"{auc_test:.2f}"]
 df_summary_new = pd.DataFrame(summary_new)
 update_summary(nervusenv.summary_dir, nervusenv.csv_summary, df_summary_new)
-
-
-# ----- EOF -----

--- a/evaluation/yy.py
+++ b/evaluation/yy.py
@@ -18,12 +18,12 @@ from lib.align_env import *
 from options.metrics_options import MetricsOptions
 
 
-args = MetricsOptions().parse()
 nervusenv = NervusEnv()
+args = MetricsOptions().parse()
 datetime_dir = get_target(nervusenv.sets_dir, args['likelihood_datetime'])   # args['likelihood_datetime'] if exists or the latest
 likelihood_path = os.path.join(datetime_dir, nervusenv.csv_likelihood)
 df_likelihood = pd.read_csv(likelihood_path)
-output_name_list = [column_name for column_name in df_likelihood.columns if column_name.startswith('output')]
+
 
 @dataclasses.dataclass
 class MetricsYY:
@@ -37,47 +37,52 @@ class LabelMetricsYY:
     val: MetricsYY
     test: MetricsYY
 
-def cal_label_metrics_yy(output_name, df_likelihood):
-    output_metrics_yy = LabelMetricsYY(val=None, test=None)
-    pred_name = 'pred_' + output_name
+
+def cal_label_metrics_yy(label_name, df_likelihood):
+    label_metrics_yy = LabelMetricsYY(val=None, test=None)
+    pred_name = 'pred_' + label_name
     for split in ['val', 'test']:
         df_likelihood_split = get_column_value(df_likelihood, 'split', [split])
-        y_obs_split = df_likelihood_split[output_name].values
+        y_obs_split = df_likelihood_split[label_name].values
         y_pred_split = df_likelihood_split[pred_name].values
         r2 = metrics.r2_score(y_obs_split, y_pred_split)
         mse = metrics.mean_squared_error(y_obs_split, y_pred_split)
         rmse = np.sqrt(mse)
         mae = metrics.mean_absolute_error(y_obs_split, y_pred_split)
         if split == 'val':
-            output_metrics_yy.val = MetricsYY(r2=r2, mse=mse, rmse=rmse, mae=mae)
+            label_metrics_yy.val = MetricsYY(r2=r2, mse=mse, rmse=rmse, mae=mae)
         else:
-            output_metrics_yy.test = MetricsYY(r2=r2, mse=mse, rmse=rmse, mae=mae)
-    print(output_name + ': ')
-    print(f"{'val':>5}, R2: {output_metrics_yy.val.r2:>5.2f}, MSE: {output_metrics_yy.val.mse:.2f}, RMES: {output_metrics_yy.val.rmse:.2f}, MAE: {output_metrics_yy.val.mae:.2f}")
-    print(f"{'test':>5}, R2: {output_metrics_yy.test.r2:>5.2f}, MSE: {output_metrics_yy.test.mse:.2f}, RMES: {output_metrics_yy.test.rmse:.2f}, MAE: {output_metrics_yy.test.mae:.2f}")
-    return output_metrics_yy
+            label_metrics_yy.test = MetricsYY(r2=r2, mse=mse, rmse=rmse, mae=mae)
+    print(label_name + ': ')
+    print(f"{'val':>5}, R2: {label_metrics_yy.val.r2:>5.2f}, MSE: {label_metrics_yy.val.mse:.2f}, RMES: {label_metrics_yy.val.rmse:.2f}, MAE: {label_metrics_yy.val.mae:.2f}")
+    print(f"{'test':>5}, R2: {label_metrics_yy.test.r2:>5.2f}, MSE: {label_metrics_yy.test.mse:.2f}, RMES: {label_metrics_yy.test.rmse:.2f}, MAE: {label_metrics_yy.test.mae:.2f}")
+    return label_metrics_yy
 
-metrics_yy = {output_name: cal_label_metrics_yy(output_name, df_likelihood) for output_name in output_name_list}
+
+# Calculate metrics
+label_list = list(df_likelihood.columns[df_likelihood.columns.str.startswith('label')])
+metrics_yy = {label_name: cal_label_metrics_yy(label_name, df_likelihood) for label_name in label_list}
+
 
 # Plot yy-graph
 len_splits = len(['vat', 'test'])
 num_rows = 1
-num_cols = len(output_name_list) * len_splits
+num_cols = len(label_list) * len_splits
 base_size = 7
 height = num_rows * base_size
 width = num_cols * height 
 
 fig = plt.figure(figsize=(width, height))
-for i in range(len(output_name_list)):
+for i in range(len(label_list)):
     offset_val = (i * len_splits) + 1
     offset_test = offset_val + 1
-    output_name = output_name_list[i]
-    pred_name = 'pred_' + output_name
+    label_name = label_list[i]
+    pred_name = 'pred_' + label_name
 
     ax_val = fig.add_subplot(num_rows,
                              num_cols,
                              offset_val,
-                             title=output_name + '\n' + 'val: Observed-Predicted Plot',
+                             title=label_name + '\n' + 'val: Observed-Predicted Plot',
                              xlabel='Observed',
                              ylabel='Predicted',
                              xmargin=0,
@@ -85,18 +90,18 @@ for i in range(len(output_name_list)):
     ax_test = fig.add_subplot(num_rows,
                               num_cols,
                               offset_test,
-                              title=output_name + '\n' + 'test: Observed-Predicted Plot',
+                              title=label_name + '\n' + 'test: Observed-Predicted Plot',
                               xlabel='Observed',
                               ylabel='Predicted',
                               xmargin=0,
                               ymargin=0)
 
     df_val = get_column_value(df_likelihood, 'split', ['val'])
-    y_obs_val = df_val[output_name].values
+    y_obs_val = df_val[label_name].values
     y_pred_val = df_val[pred_name].values
 
     df_test = get_column_value(df_likelihood, 'split', ['test'])
-    y_obs_test = df_test[output_name].values
+    y_obs_test = df_test[label_name].values
     y_pred_test = df_test[pred_name].values
 
     y_values_val = np.concatenate([y_obs_val.flatten(), y_pred_val.flatten()])
@@ -127,19 +132,16 @@ fig.savefig(yy_path)
 datetime = os.path.basename(datetime_dir)
 summary_new = dict()
 summary_new['datetime'] = [datetime]
-for output_name in metrics_yy.keys():
-    output_metrics_yy = metrics_yy[output_name]
-    summary_new[output_name+'_val_r2'] = [f"{output_metrics_yy.val.r2:.2f}"]
-    summary_new[output_name+'_val_mse'] = [f"{output_metrics_yy.val.mse:.2f}"]
-    summary_new[output_name+'_val_rmse'] = [f"{output_metrics_yy.val.rmse:.2f}"]
-    summary_new[output_name+'_val_mae'] = [f"{output_metrics_yy.val.mae:.2f}"]
+for label_name in metrics_yy.keys():
+    label_metrics_yy = metrics_yy[label_name]
+    summary_new[label_name+'_val_r2'] = [f"{label_metrics_yy.val.r2:.2f}"]
+    summary_new[label_name+'_val_mse'] = [f"{label_metrics_yy.val.mse:.2f}"]
+    summary_new[label_name+'_val_rmse'] = [f"{label_metrics_yy.val.rmse:.2f}"]
+    summary_new[label_name+'_val_mae'] = [f"{label_metrics_yy.val.mae:.2f}"]
 
-    summary_new[output_name+'_test_r2'] = [f"{output_metrics_yy.test.r2:.2f}"]
-    summary_new[output_name+'_test_mse'] = [f"{output_metrics_yy.test.mse:.2f}"]
-    summary_new[output_name+'_test_rmse'] = [f"{output_metrics_yy.test.rmse:.2f}"]
-    summary_new[output_name+'_test_mae'] = [f"{output_metrics_yy.test.mae:.2f}"]
+    summary_new[label_name+'_test_r2'] = [f"{label_metrics_yy.test.r2:.2f}"]
+    summary_new[label_name+'_test_mse'] = [f"{label_metrics_yy.test.mse:.2f}"]
+    summary_new[label_name+'_test_rmse'] = [f"{label_metrics_yy.test.rmse:.2f}"]
+    summary_new[label_name+'_test_mae'] = [f"{label_metrics_yy.test.mae:.2f}"]
 df_summary_new = pd.DataFrame(summary_new)
 update_summary(nervusenv.summary_dir, nervusenv.csv_summary, df_summary_new)
-
-
-# ----- EOF -----

--- a/lib/align_env.py
+++ b/lib/align_env.py
@@ -26,85 +26,106 @@ class NervusEnv:
     csv_summary: str = 'summary.csv'
 
 
-def parse_csv(csv_path, task):
-    csv_dict = {} 
-    prefix_id = 'id'  # 'id'
-    prefix_input = 'input'
-    prefix_output = 'output'
-    prefix_label = 'label'
-    prefix_period = 'periods'
+class SplitProvider:
+    def __init__(self, split_path, task):
+        super().__init__()
 
-    csv_dict['filepath_column'] = 'filepath'
-    csv_dict['split_column'] = 'split'
+        self.split_path = split_path
+        self.task = task
 
-    # Exclude
-    df_source = pd.read_csv(csv_path)
-    df_source = df_source[df_source[csv_dict['split_column']] != 'exclude']
+        self.prefix_id = 'id'
+        self.prefix_input = 'input'
+        self.prefix_label = 'label'
+        self.prefix_internal_label = 'internal'
+        self.prefix_period = 'periods'
 
-    # Make dict for labeling
-    # csv_dict['output_class_label'] =
-    # {'output_1':{'A':0, 'B':1}, 'output_2':{'C':0, 'D':1, 'E':2}, ...}   classification
-    # {'output_1':{}, 'output_2':{}, ...}                                  regression 
-    # {'output_1':{'A':0, 'B':1}}                                          deepsurv
-    csv_dict['output_list'] = [column_name for column_name in list(df_source.columns) if column_name.startswith(prefix_output)]
-    output_class_label_dict = {}
-    for output_name in csv_dict['output_list']:
-        class_list = df_source[output_name].value_counts().index.tolist()
-        output_class_label_dict[output_name] = {}
-        if (task == 'classification') or (task == 'deepsurv'):
-             for i in range(len(class_list)):
-                output_class_label_dict[output_name][class_list[i]] = i
+        self.filepath_column = 'filepath'
+        self.split_column = 'split'
+
+        _df_source = pd.read_csv(self.split_path)
+        _df_source = _df_source[_df_source[self.split_column] != 'exclude'].copy()
+        _df_source_labeled, self.class_name_in_label = self._make_labelling(_df_source, self.task)   # Labeling
+
+        # cast
+        self.df_source = self._cast_csv(_df_source_labeled, task)
+        self.label_num_classes = self._define_label_num_classes(self.df_source, self.task)    # After labeling, column names are fixed.
+
+        self.label_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_label)])
+        self.internal_label_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_internal_label)])
+        self.input_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_input)])
+        self.num_inputs = len(self.input_list)
+
+        if self.task == 'deepsurv':
+            self.period_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_period)])[0]  # should be one
         else:
-            output_class_label_dict[output_name] = {}   # No need of labeling
-    csv_dict['output_class_label'] = output_class_label_dict
+            self.period_column = None
+
 
     # Labeling
-    for output_name, class_label_dict in output_class_label_dict.items():
-        if (task == 'classification') or (task == 'deepsurv'):
-            for class_name, label in class_label_dict.items():
-                df_source.loc[df_source[output_name]==class_name, (prefix_label + '_' + output_name)] = label
-        else:
-            df_source[(prefix_label + '_' + output_name)] = df_source[output_name]   # Just copy. Needed because labeL_XXX will be cast later.
+    def _make_labelling(self, df_source, task):
+        # Make dict for labeling
+        # _class_name_in_label =
+        # {'label_1':{'A':0, 'B':1}, 'label_2':{'C':0, 'D':1, 'E':2}, ...}   classification
+        # {'label_1':{}, 'label_2':{}, ...}                                  regression
+        # {'label_1':{'A':0, 'B':1}}                                         deepsurv
+        _df_tmp = df_source.copy()
+        _label_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_label)])
+        _class_name_in_label = {}
+        for label_name in _label_list:
+            class_list = _df_tmp[label_name].value_counts().index.tolist()    # {'A', 'B', ... } decending order
+            _class_name_in_label[label_name] = {}
+            if (task == 'classification') or (task == 'deepsurv'):
+                 for i in range(len(class_list)):
+                    _class_name_in_label[label_name][class_list[i]] = i
+            else:
+                _class_name_in_label[label_name] = {}                         # No need of labeling
 
-    # After labeling, column names are fixed.
-    column_names = list(df_source.columns)
+        # Labeling
+        for label_name, class_name_in_label in _class_name_in_label.items():
+            _internal_label = self.prefix_internal_label + '_' + label_name      # label_XXX -> internal_label_XXX
+            if (task == 'classification') or (task == 'deepsurv'):
+                for class_name, ground_truth in class_name_in_label.items():
+                    _df_tmp.loc[_df_tmp[label_name]==class_name, _internal_label] = ground_truth
+            else:
+                _df_tmp[_internal_label] = _df_tmp[label_name]    # Just copy. Needed because internal_label_XXX will be cast later.
 
-    # Define the number of outputs of mode
-    # csv_dict['label_num_classes'] =
-    # {label_output_1: 2, label_output_2: 3, ...}   classification
-    # {label_output_1: 1, label_output_2: 1, ...}   regression,  should be 1
-    # {label_output_1: 1}                           deepsurv,    should be 1
-    csv_dict['label_list'] = [column_name for column_name in column_names if column_name.startswith(prefix_label)]
-    csv_dict['label_num_classes'] = {}
-    for label_name in csv_dict['label_list']:
-        if task == 'classification':
-            csv_dict['label_num_classes'][label_name] = df_source[label_name].nunique()
-        else:
-            # When regression or deepsurv
-            csv_dict['label_num_classes'][label_name] = 1
+        return _df_tmp, _class_name_in_label
 
-    csv_dict['id_column'] = [column_name for column_name in column_names if column_name.startswith(prefix_id)][0]   # should be one
-    csv_dict['input_list'] = [column_name for column_name in column_names if column_name.startswith(prefix_input)]
-    csv_dict['num_inputs'] = len(csv_dict['input_list'])
 
-    if task == 'deepsurv':
-        csv_dict['period_column'] = [column_name for column_name in column_names if column_name.startswith(prefix_period)][0]   # should be one
-    else:
-        csv_dict['period_column'] = None
+    def _define_label_num_classes(self, df_source, task):
+        # _label_num_classes
+        # {label_output_1: 2, label_output_2: 3, ...}   classification
+        # {label_output_1: 1, label_output_2: 1, ...}   regression,  should be 1
+        # {label_output_1: 1}                           deepsurv,    should be 1
+        _label_num_classes = {}
+        _label_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_label)])
+        for label_name in _label_list:
+            if task == 'classification':
+                _label_num_classes[label_name] = df_source[label_name].nunique()
+            else:
+                _label_num_classes[label_name] = 1
+
+        return _label_num_classes
+
 
     # Cast
-    # label_* : int
-    # input_* : float
-    cast_input_dict = {input: float for input in csv_dict['input_list']}
-    if task == 'classification':
-        cast_label_dict = {label: int for label in csv_dict['label_list']}
-    else:
-        # When regression or deepsurv
-        cast_label_dict = {label: float for label in csv_dict['label_list']}
-    df_source = df_source.astype(cast_input_dict)
-    df_source = df_source.astype(cast_label_dict)
+    def _cast_csv(self, df_source, task):
+        # label_* : int
+        # input_* : float
+        _df_tmp = df_source.copy()
+        _input_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_input)])
+        _internal_label_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_internal_label)])
 
-    csv_dict['source'] = df_source
-    return csv_dict
+        _cast_input_dict = {input: float for input in _input_list}
+        
+        if task == 'classification':
+            _cast_internal_label_dict = {label: int for label in _internal_label_list}
+        else:
+            # When regression or deepsurv
+            _cast_internal_label_dict = {label: float for label in _internal_label_list}
 
-# ----- EOF -----
+        _df_tmp = _df_tmp.astype(_cast_input_dict)
+        _df_tmp = _df_tmp.astype(_cast_internal_label_dict)
+
+        return _df_tmp
+

--- a/lib/align_env.py
+++ b/lib/align_env.py
@@ -21,7 +21,6 @@ class NervusEnv:
     roc: str = 'roc.png'
     yy: str = 'yy.png'
     csv_c_index: str = 'c_index.csv'
-    visualization_dir: str = 'visualization'
     summary_dir: str = os.path.join(reslts_dir, 'summary')
     csv_summary: str = 'summary.csv'
 
@@ -35,25 +34,30 @@ class SplitProvider:
 
         self.prefix_id = 'id'
         self.prefix_input = 'input'
-        self.prefix_label = 'label'
-        self.prefix_internal_label = 'internal'
+        self.prefix_raw_label = 'label'
+        self.prefix_internal_label = 'internal_label'
         self.prefix_period = 'periods'
 
         self.filepath_column = 'filepath'
         self.split_column = 'split'
 
         _df_source = pd.read_csv(self.split_path)
-        _df_source = _df_source[_df_source[self.split_column] != 'exclude'].copy()
-        _df_source_labeled, self.class_name_in_label = self._make_labelling(_df_source, self.task)   # Labeling
+        _df_source_excluded = _df_source[_df_source[self.split_column] != 'exclude'].copy()
 
-        # cast
-        self.df_source = self._cast_csv(_df_source_labeled, task)
-        self.label_num_classes = self._define_label_num_classes(self.df_source, self.task)    # After labeling, column names are fixed.
+        # Labelling
+        _df_source_labeled, _class_name_in_raw_label = self._make_labelling(_df_source_excluded, self.task) 
 
-        self.label_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_label)])
+        # Cast
+        self.df_source = self._cast_csv(_df_source_labeled, self.task)
+
+        # After labeling, column names are fixed.
+        self.raw_label_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_raw_label)])
         self.internal_label_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_internal_label)])
+        self.class_name_in_raw_label = _class_name_in_raw_label
+        self.num_classes_in_internal_label = self._define_num_classes_in_internal_label(self.df_source, self.task)  
         self.input_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_input)])
         self.num_inputs = len(self.input_list)
+        self.id_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_id)])[0]   # should be one
 
         if self.task == 'deepsurv':
             self.period_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_period)])[0]  # should be one
@@ -62,59 +66,61 @@ class SplitProvider:
 
 
     # Labeling
-    def _make_labelling(self, df_source, task):
+    def _make_labelling(self, df_source_excluded, task):
         # Make dict for labeling
         # _class_name_in_label =
         # {'label_1':{'A':0, 'B':1}, 'label_2':{'C':0, 'D':1, 'E':2}, ...}   classification
         # {'label_1':{}, 'label_2':{}, ...}                                  regression
         # {'label_1':{'A':0, 'B':1}}                                         deepsurv
-        _df_tmp = df_source.copy()
-        _label_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_label)])
-        _class_name_in_label = {}
-        for label_name in _label_list:
-            class_list = _df_tmp[label_name].value_counts().index.tolist()    # {'A', 'B', ... } decending order
-            _class_name_in_label[label_name] = {}
+        _df_tmp = df_source_excluded.copy()
+        _raw_label_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_raw_label)])
+        _class_name_in_raw_label = {}
+        for raw_label_name in _raw_label_list:
+            class_list = _df_tmp[raw_label_name].value_counts().index.tolist()    # {'A', 'B', ... } decending order
+            _class_name_in_raw_label[raw_label_name] = {}
             if (task == 'classification') or (task == 'deepsurv'):
                  for i in range(len(class_list)):
-                    _class_name_in_label[label_name][class_list[i]] = i
+                    _class_name_in_raw_label[raw_label_name][class_list[i]] = i
             else:
-                _class_name_in_label[label_name] = {}                         # No need of labeling
+                _class_name_in_raw_label[raw_label_name] = {}                         # No need of labeling
 
         # Labeling
-        for label_name, class_name_in_label in _class_name_in_label.items():
-            _internal_label = self.prefix_internal_label + '_' + label_name      # label_XXX -> internal_label_XXX
+        for raw_label_name, class_name_in_raw_label in _class_name_in_raw_label.items():
+            _internal_label = self.prefix_internal_label + raw_label_name.replace(self.prefix_raw_label, '')   # label_XXX -> internal_label_XXX
             if (task == 'classification') or (task == 'deepsurv'):
-                for class_name, ground_truth in class_name_in_label.items():
-                    _df_tmp.loc[_df_tmp[label_name]==class_name, _internal_label] = ground_truth
+                for class_name, ground_truth in class_name_in_raw_label.items():
+                    _df_tmp.loc[_df_tmp[raw_label_name]==class_name, _internal_label] = ground_truth
             else:
-                _df_tmp[_internal_label] = _df_tmp[label_name]    # Just copy. Needed because internal_label_XXX will be cast later.
+                _df_tmp[_internal_label] = _df_tmp[raw_label_name]    # Just copy. Needed because internal_label_XXX will be cast later.
 
-        return _df_tmp, _class_name_in_label
+        _df_source_labeled = _df_tmp.copy()
+        return _df_source_labeled, _class_name_in_raw_label
 
 
-    def _define_label_num_classes(self, df_source, task):
-        # _label_num_classes
-        # {label_output_1: 2, label_output_2: 3, ...}   classification
-        # {label_output_1: 1, label_output_2: 1, ...}   regression,  should be 1
-        # {label_output_1: 1}                           deepsurv,    should be 1
-        _label_num_classes = {}
-        _label_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_label)])
-        for label_name in _label_list:
+    def _define_num_classes_in_internal_label(self, df_source, task):
+        # _num_classes_of_label =
+        # {internal_label_output_1: 2, internal_label_output_2: 3, ...}   classification
+        # {internal_label_output_1: 1, internal_label_output_2: 1, ...}   regression,  should be 1
+        # {internal_label_output_1: 1}                                    deepsurv,    should be 1
+        _num_classes_in_internal_label = {}
+        _internal_label_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_internal_label)])
+        for internal_label_name in _internal_label_list:
             if task == 'classification':
-                _label_num_classes[label_name] = df_source[label_name].nunique()
+                _num_classes_in_internal_label[internal_label_name] = df_source[internal_label_name].nunique()
             else:
-                _label_num_classes[label_name] = 1
+                # When regression or deepsurv
+                _num_classes_in_internal_label[internal_label_name] = 1
 
-        return _label_num_classes
+        return _num_classes_in_internal_label
 
 
     # Cast
-    def _cast_csv(self, df_source, task):
+    def _cast_csv(self, df_source_labeled, task):
         # label_* : int
         # input_* : float
-        _df_tmp = df_source.copy()
-        _input_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_input)])
-        _internal_label_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_internal_label)])
+        _df_tmp = df_source_labeled.copy()
+        _input_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_input)])
+        _internal_label_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_internal_label)])
 
         _cast_input_dict = {input: float for input in _input_list}
         

--- a/lib/align_env.py
+++ b/lib/align_env.py
@@ -45,7 +45,7 @@ class SplitProvider:
         _df_source_excluded = _df_source[_df_source[self.split_column] != 'exclude'].copy()
 
         # Labelling
-        _df_source_labeled, _class_name_in_raw_label = self._make_labelling(_df_source_excluded, self.task) 
+        _df_source_labeled, _class_name_in_raw_label = self._make_labelling(_df_source_excluded, self.task)
 
         # Cast
         self.df_source = self._cast_csv(_df_source_labeled, self.task)
@@ -57,10 +57,10 @@ class SplitProvider:
         self.num_classes_in_internal_label = self._define_num_classes_in_internal_label(self.df_source, self.task)  
         self.input_list = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_input)])
         self.num_inputs = len(self.input_list)
-        self.id_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_id)])[0]   # should be one
+        self.id_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_id)])[0]               # should be one
 
         if self.task == 'deepsurv':
-            self.period_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_period)])[0]  # should be one
+            self.period_column = list(self.df_source.columns[self.df_source.columns.str.startswith(self.prefix_period)])[0]   # should be one
         else:
             self.period_column = None
 
@@ -68,21 +68,21 @@ class SplitProvider:
     # Labeling
     def _make_labelling(self, df_source_excluded, task):
         # Make dict for labeling
-        # _class_name_in_label =
+        # _class_name_in_raw_label =
         # {'label_1':{'A':0, 'B':1}, 'label_2':{'C':0, 'D':1, 'E':2}, ...}   classification
         # {'label_1':{}, 'label_2':{}, ...}                                  regression
-        # {'label_1':{'A':0, 'B':1}}                                         deepsurv
+        # {'label_1':{'A':0, 'B':1}}                                         deepsurv, should be 2 classes only
         _df_tmp = df_source_excluded.copy()
         _raw_label_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_raw_label)])
         _class_name_in_raw_label = {}
         for raw_label_name in _raw_label_list:
-            class_list = _df_tmp[raw_label_name].value_counts().index.tolist()    # {'A', 'B', ... } decending order
+            class_list = _df_tmp[raw_label_name].value_counts().index.tolist()   # {'A', 'B', ... } decending order
             _class_name_in_raw_label[raw_label_name] = {}
             if (task == 'classification') or (task == 'deepsurv'):
                  for i in range(len(class_list)):
                     _class_name_in_raw_label[raw_label_name][class_list[i]] = i
             else:
-                _class_name_in_raw_label[raw_label_name] = {}                         # No need of labeling
+                _class_name_in_raw_label[raw_label_name] = {}                    # No need of labeling
 
         # Labeling
         for raw_label_name, class_name_in_raw_label in _class_name_in_raw_label.items():
@@ -91,6 +91,7 @@ class SplitProvider:
                 for class_name, ground_truth in class_name_in_raw_label.items():
                     _df_tmp.loc[_df_tmp[raw_label_name]==class_name, _internal_label] = ground_truth
             else:
+                # When regression
                 _df_tmp[_internal_label] = _df_tmp[raw_label_name]    # Just copy. Needed because internal_label_XXX will be cast later.
 
         _df_source_labeled = _df_tmp.copy()
@@ -98,7 +99,7 @@ class SplitProvider:
 
 
     def _define_num_classes_in_internal_label(self, df_source, task):
-        # _num_classes_of_label =
+        # _num_classes_in_internal_label =
         # {internal_label_output_1: 2, internal_label_output_2: 3, ...}   classification
         # {internal_label_output_1: 1, internal_label_output_2: 1, ...}   regression,  should be 1
         # {internal_label_output_1: 1}                                    deepsurv,    should be 1
@@ -106,6 +107,8 @@ class SplitProvider:
         _internal_label_list = list(df_source.columns[df_source.columns.str.startswith(self.prefix_internal_label)])
         for internal_label_name in _internal_label_list:
             if task == 'classification':
+                # Actually _num_classes_in_internal_label can be made from self.class_name_in_raw_label, however
+                # it might be natural to count the number of classes in each internal label.
                 _num_classes_in_internal_label[internal_label_name] = df_source[internal_label_name].nunique()
             else:
                 # When regression or deepsurv
@@ -123,15 +126,15 @@ class SplitProvider:
         _internal_label_list = list(_df_tmp.columns[_df_tmp.columns.str.startswith(self.prefix_internal_label)])
 
         _cast_input_dict = {input: float for input in _input_list}
-        
+
         if task == 'classification':
-            _cast_internal_label_dict = {label: int for label in _internal_label_list}
+            _cast_internal_label_dict = {internal_label: int for internal_label in _internal_label_list}
         else:
             # When regression or deepsurv
-            _cast_internal_label_dict = {label: float for label in _internal_label_list}
+            _cast_internal_label_dict = {internal_label: float for internal_label in _internal_label_list}
 
         _df_tmp = _df_tmp.astype(_cast_input_dict)
         _df_tmp = _df_tmp.astype(_cast_internal_label_dict)
 
-        return _df_tmp
-
+        _df_casted = _df_tmp.copy()
+        return _df_casted

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -12,7 +12,7 @@ class TrainOptions():
         self.parser = argparse.ArgumentParser(description='Train options')
 
         # Materials
-        self.parser.add_argument('--csv_name',  type=str, default=None, help='csv namefilename(Default: None)')
+        self.parser.add_argument('--csv_name',  type=str, default=None, help='csv filename(Default: None)')
         self.parser.add_argument('--image_dir', type=str, default=None, help='directory name contaning images(Default: None)')
 
         # Task
@@ -31,7 +31,6 @@ class TrainOptions():
         self.parser.add_argument('--batch_size',      type=int, default=None, metavar='N', help='batch size for training (Default: None)')
 
         # Preprocess for image
-        self.parser.add_argument('--preprocess',             type=str, default=None,  help='preprocess for image, yes or no (Default: None)')        
         self.parser.add_argument('--random_horizontal_flip', type=str, default=None,  help='RandomHorizontalFlip, yes or no (Default: None)')
         self.parser.add_argument('--random_rotation',        type=str, default=None,  help='RandomRotation, yes or no (Default: None)')
         self.parser.add_argument('--color_jitter',           type=str, default=None,  help='ColorJitter, yes or no (Default: None)')
@@ -76,15 +75,34 @@ class TrainOptions():
             pass
             #Check the case of when no specifying model later
 
-        if self.args.augmentation == 'yes':
-            # Apply all augmentation forcedly
-            self.args.preprocess = 'yes'
-            self.args.random_horizontal_flip = 'yes'
-            self.args.random_rotation = 'yes'
-            self.args.color_jitter = 'yes'
-        else:
-            pass
 
+        # Align options for augmentation
+        # Note: Add transfomrtation to this list
+        _augmentation_list = [self.args.random_horizontal_flip, self.args.random_rotation, self.args.color_jitter]
+        num_partial_aug = _augmentation_list.count('yes')
+        is_partial_aug = (0 < num_partial_aug) and (num_partial_aug < len(_augmentation_list))   # Not all
+        is_all_aug = (self.args.augmentation == 'yes')                 # All
+
+        if num_partial_aug == len(_augmentation_list):
+            print('Specify --augumentaion yes only if apply all augmention.\n')
+            exit()
+
+        if is_partial_aug or is_all_aug:
+            self.args.preprocess = 'yes'
+            if is_partial_aug and (not is_all_aug):
+                # Not all
+                pass
+            elif (not is_partial_aug) and is_all_aug:
+                # Apply all augmentation forcedly
+                self.args.random_horizontal_flip = 'yes'
+                self.args.random_rotation = 'yes'
+                self.args.color_jitter = 'yes'
+            else:
+                # When is_partial_aug and is_all_aug, contradiction.
+                print('Apply not all augmentation, or Apply all augmentation?\n')
+                exit()
+        else:
+            self.args.preprocess = 'no'
 
         # Align gpu_ids
         str_ids = self.args.gpu_ids.split(',')

--- a/test.py
+++ b/test.py
@@ -32,8 +32,8 @@ label_list = sp.internal_label_list   # Reagrd internal label as label
 
 # Align option for test only
 test_weight = os.path.join(datetime_dir, nervusenv.weight)
-test_batch_size = args['test_batch_size']                            # Default: 64  No exixt in train_opt
-train_parameters['preprocess'] = 'no'                           # MUST: Stop augumentation, No need of preprocess for image when test
+test_batch_size = args['test_batch_size']                       # Default: 64  No exixt in train_opt
+train_parameters['preprocess'] = 'no'                           # MUST: Stop augmentaion, No need when test
 train_parameters['normalize_image'] = args['normalize_image']   # Default: 'yes'
 
 


### PR DESCRIPTION
- modified:   Makefile
- modified:   config/model.py
- modified:   dataloader/dataloader.py
- modified:   dataloader/dataloader_deepsurv.py
- modified:   dataloader/dataloader_multi.py
- modified:   evaluation/c_index.py
- modified:   evaluation/roc.py
- modified:   evaluation/yy.py
- modified:   lib/align_env.py
- modified:   test.py
- modified:   train.py
- modified:   options/train_options.py
- modified:   README.md

Throughout all codes, `'output_'` has been renamed `'label_'`.
Note that variable `raw_label` indicates `'label_XXX'` in `splits.csv`, and variable `internal_label` indicates label which is handled by Nervus inside.

`lib/align_env.py`,
`def parse_csv()` has been changed to a class named `SplitProvider`.

`Makefile`
Deleted lines related visualization.

`options/train_options.py`
Deleted `--preprocess` option to avoid unexpected mistake. 
