### PR TITLE
Modified so that pretrained model of CNN or ViT could be used.

### DIFF
--- a/lib/component/dataloader.py
+++ b/lib/component/dataloader.py
@@ -179,6 +179,7 @@ class InputDataMixin:
         Returns:
             MinMaxScaler: scaler
         """
+        assert (self.input_list != []), 'No tabular data.'
         if scaler_path is None:
             scaler = MinMaxScaler()
             _df_train = self.df_source[self.df_source['split'] == 'train']  # should be normalized with min and max of training data
@@ -286,10 +287,10 @@ class ImageMixin:
         assert (self.params.in_channel is not None), 'Speficy in_channel by 1 or 3.'
         imgpath = self.df_split.iat[idx, self.col_index_dict['imgpath']]
         if self.params.in_channel == 1:
-            image = Image.open(imgpath).convert('L')
+            image = Image.open(imgpath).convert('L')    # eg. np.array(image).shape = (64, 64)
         else:
             # ie. self.params.in_channel == 3
-            image = Image.open(imgpath).convert('RGB')
+            image = Image.open(imgpath).convert('RGB')  # eg. np.array(image).shape = (64, 64, 3)
 
         image = self.augmentation(image)
         image = self.transform(image)

--- a/lib/framework.py
+++ b/lib/framework.py
@@ -33,7 +33,7 @@ class BaseModelParam:
         for _param, _arg in vars(args).items():
             setattr(self, _param, _arg)
 
-        self._dataset_dir = re.findall('(.*)/docs', self.csvpath)[0]
+        self._dataset_dir = re.findall('(.*)/docs', self.csvpath)[0]  # shoubd be unique
         self._csv_name = Path(self.csvpath).stem
 
     def print_parameter(self) -> None:
@@ -63,7 +63,7 @@ class BaseModelParam:
 
         for _param, _arg in vars(self).items():
             if _param not in no_print:
-                _str_arg = self._format_arg(_param, _arg)
+                _str_arg = self._arg2str(_param, _arg)
                 message += '{:>25}: {:<40}\n'.format(_param, _str_arg)
             else:
                 pass
@@ -71,7 +71,7 @@ class BaseModelParam:
         message += f"{'-'*30} End {'-'*48}\n"
         logger.logger.info(message)
 
-    def _format_arg(self, param: str, arg: Union[str, int, float]) -> str:
+    def _arg2str(self, param: str, arg: Union[str, int, float]) -> str:
         """
         Convert argument to string.
 
@@ -253,6 +253,10 @@ class TestModelParam(BaseModelParam):
         self.augmentation = 'no'
         self.sampler = 'no'
 
+        # Use saved weight at test
+        # saved weight is load in test.py.
+        self.pretrained = False
+
         sp = make_split_provider(self.csvpath, self.task)
         self.device = torch.device(f"cuda:{self.gpu_ids[0]}") if self.gpu_ids != [] else torch.device('cpu')
 
@@ -302,7 +306,8 @@ class BaseModel(ABC):
                                 self.params.num_outputs_for_label,
                                 self.params.mlp_num_inputs,
                                 self.params.in_channel,
-                                self.params.vit_image_size
+                                self.params.vit_image_size,
+                                self.params.pretrained
                                 )
 
         if self.params.isTrain:
@@ -869,5 +874,5 @@ def create_model(
     if params.isTrain:
         model._enable_on_gpu_if_available()
     # When test, execute model._enable_on_gpu_if_available() in load_weight(),
-    # ie. after loadding weight.
+    # ie. after loading weight.
     return model

--- a/lib/options.py
+++ b/lib/options.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
+import argparse
+from distutils.util import strtobool
 from pathlib import Path
 import re
-import argparse
 from typing import List, Tuple, Union
 
 
@@ -27,7 +29,8 @@ class Options:
             self.parser.add_argument('--task',  type=str, required=True, choices=['classification', 'regression', 'deepsurv'], help='Task')
 
             # Model
-            self.parser.add_argument('--model', type=str, required=True, help='model: MLP, CNN, ViT, or MLP+(CNN or ViT)')
+            self.parser.add_argument('--model',      type=str, required=True, help='model: MLP, CNN, ViT, or MLP+(CNN or ViT)')
+            self.parser.add_argument('--pretrained', type=strtobool, default=False, help='For use of pretrained model(CNN or ViT)')
 
             # Training and Internal validation
             self.parser.add_argument('--criterion', type=str,   required=True, choices=['CEL', 'MSE', 'RMSE', 'MAE', 'NLL'], help='criterion')
@@ -130,6 +133,9 @@ class Options:
             _mlp, _net = self._parse_model(self.args.model)
             setattr(self.args, 'mlp', _mlp)
             setattr(self.args, 'net', _net)
+
+            _pretrained = bool(self.args.pretrained)   # strtobool('False') = 0 (== False)
+            setattr(self.args, 'pretrained', _pretrained)
 
             _gpu_ids = self._parse_gpu_ids(self.args.gpu_ids)
             setattr(self.args, 'gpu_ids', _gpu_ids)

--- a/test.py
+++ b/test.py
@@ -37,7 +37,7 @@ def main(opt):
     for weight_path in weight_paths:
         logger.logger.info(f"Inference with {weight_path.name}.")
 
-        # weight is reset, or overwritten every time.
+        # weight is reset by overwriting every time.
         model.load_weight(weight_path)
         model.eval()
 


### PR DESCRIPTION
pretrained model can be handled.
Default wetight of prtrained model is used by specifying like `weights='DEFAULT'` .

modified:   test.py
modified:   lib/options.py
modified:   lib/component/net.py
modified:   lib/framework.py
modified:   lib/component/dataloader.py

