### PR TITLE
Avoid warning when DDP with ConvNeXt

### DIFF
--- a/lib/component/__init__.py
+++ b/lib/component/__init__.py
@@ -7,8 +7,13 @@ from .optimizer import set_optimizer
 from .loss import set_loss_store
 from .likelihood import set_likelihood
 
+from .net import replace_all_layer_type_recursive_Permute
+
 __all__ = [
             'create_net',
+
+            'replace_all_layer_type_recursive_Permute',
+
             'set_criterion',
             'set_optimizer',
             'set_loss_store',

--- a/lib/component/net.py
+++ b/lib/component/net.py
@@ -673,7 +673,7 @@ class LayerNorm2dC(nn.LayerNorm):
         #self.elementwise_affine = elementwise_affine
 
     def forward(self, x: Tensor) -> Tensor:
-        x = x.permute(0, 2, 3, 1).contiguous()
+        x = x.permute(0, 2, 3, 1).contiguous()  # although it is OK even if not contiguous.
         x = F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
         x = x.permute(0, 3, 1, 2).contiguous()
         return x

--- a/lib/component/net.py
+++ b/lib/component/net.py
@@ -721,12 +721,15 @@ def replace_all_layer_type_recursive_Permute(model):
             dims = layer.dims
             model._modules[name] = PermuteC(dims)
 
-        if isinstance(layer, LayerNorm2d):
+        elif isinstance(layer, LayerNorm2d):
             normalized_shape = layer.normalized_shape
             #weight = layer.weight
             #bias = layer.bias
             eps = layer.eps
             model._modules[name] = LayerNorm2dC(normalized_shape, eps)
+
+        else:
+            pass
 
         replace_all_layer_type_recursive_Permute(layer)
 

--- a/lib/framework.py
+++ b/lib/framework.py
@@ -13,6 +13,10 @@ from lib import ParamSet
 from typing import List, Dict, Tuple, Union
 
 
+from .component import replace_all_layer_type_recursive_Permute
+
+
+
 # Alias of typing
 # eg. {'labels': {'label_A: torch.Tensor([0, 1, ...]), ...}}
 LabelDict = Dict[str, Dict[str, Union[torch.IntTensor, torch.FloatTensor]]]

--- a/train.py
+++ b/train.py
@@ -52,6 +52,12 @@ def train(
     device = set_device(rank=rank, gpu_ids=args_conf.gpu_ids)
     model = create_model(args_model)
     model.network.to(device)
+
+    #!---------------------
+    if isMaster:
+        print(model.network)
+    #!---------------------
+
     if isDistributed:
         # When device_ids = None of DDP,
         # both the input data for the forward pass and the actual module


### PR DESCRIPTION
NOTE: The modification of this branch will be merged into the branch refactor_net.

modified:   lib/component/__init__.py
modified:   lib/component/net.py
modified:   lib/framework.py
modified:   train.py

This is to avoid a warning when DDP with ConvNeXt.

・Symptom:
When DDP with ConvNeXt starts, the following warning occurs at the first iteration of the first epoch.

```
UserWarning: Grad strides do not match bucket view strides. This may indicate grad was not created according to the gradient layout contract, or that the param's strides changed since DDP was constructed.  This is not an error, but may impair performance.
grad.sizes() = [1024, 1, 7, 7], strides() = [49, 1, 7, 1]
bucket_view.sizes() = [1024, 1, 7, 7], strides() = [49, 49, 7, 1] (Triggered internally at ../torch/csrc/distributed/c10d/reducer.cpp:323.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
```

・Root cause:
After tensor is permuted, the element of the tensor is not in a contiguous in memory.

・What has been done:
   -Modified classes Permute() and LayerNorm2d() by adding .contigious() …after permutation.
   -Defined PermuteC() and LayerNorm2dC().
   -Replace Permute() and LayerNorm2d() of original ConvNeXt with Permute() and LayerNorm2d(), respectively.


The modification in this branch has been merged into the following pull request:
https://github.com/Medical-AI-Lab/Nervus/pull/96.

